### PR TITLE
Minimum Size for Hotspots

### DIFF
--- a/src/components/viewer/hotspots/HotspotUtils.ts
+++ b/src/components/viewer/hotspots/HotspotUtils.ts
@@ -448,17 +448,33 @@ export async function createHotspotGeometry(direction: string): Promise<{
 }
 
 /**
+ * Minimum scale factor for navigation hotspots
+ *
+ * Prevents navigation hotspots (elevator/stairs/door) from becoming too small
+ * when zoomed out, maintaining visibility and usability at all zoom levels.
+ */
+export const MIN_NAVIGATION_HOTSPOT_SCALE = 0.825
+
+/**
  * Calculate dynamic scale for hotspot based on camera zoom level
  *
  * Adjusts hotspot size based on field of view to maintain visibility
  * and readability at different zoom levels.
  *
  * @param fov - Current camera field of view in degrees
+ * @param applyMinimum - Whether to apply minimum scale (true for navigation hotspots, false for hidden locations)
  * @returns Scale factor for hotspot size
  */
-export function calculateHotspotScale(fov: number): number {
+export function calculateHotspotScale(fov: number, applyMinimum: boolean = true): number {
   // Scale between 0.5 and 1.5 based on FOV (10-120 degrees)
-  return (120 - fov) / 100 + 0.5
+  const scale = (120 - fov) / 100 + 0.5
+
+  // Apply minimum scale for navigation hotspots only
+  if (applyMinimum) {
+    return Math.max(scale, MIN_NAVIGATION_HOTSPOT_SCALE)
+  }
+
+  return scale
 }
 
 /**

--- a/src/components/viewer/hotspots/PanoramicHotspots.tsx
+++ b/src/components/viewer/hotspots/PanoramicHotspots.tsx
@@ -123,16 +123,20 @@ export const PanoramicHotspots: React.FC<PanoramicHotspotsProps> = ({
   const updateHotspotDisplay = useCallback(() => {
     if (!hotspotsGroupRef.current) return
 
-    const scale = calculateHotspotScale(fov)
-    const hiddenLocationScale = scale * HIDDEN_LOCATION_SCALE_FACTOR
-
     hotspotsGroupRef.current.children.forEach((object) => {
       const hotspotType = object.userData?.type
 
       object.visible = true
-      object.scale.setScalar(
-        hotspotType === 'hiddenLocation' ? hiddenLocationScale : scale
-      )
+
+      if (hotspotType === 'hiddenLocation') {
+        // Hidden locations scale normally without minimum, and apply size factor
+        const hiddenLocationScale = calculateHotspotScale(fov, false) * HIDDEN_LOCATION_SCALE_FACTOR
+        object.scale.setScalar(hiddenLocationScale)
+      } else {
+        // Navigation hotspots (elevator/stairs/door) have minimum size
+        const navigationScale = calculateHotspotScale(fov, true)
+        object.scale.setScalar(navigationScale)
+      }
     })
   }, [fov])
 


### PR DESCRIPTION
Minimum size for elevator, floor, stair and door hotspots but not hidden location hotspots to stop users from just zooming out and being able to easily find the hidden locations